### PR TITLE
Resolve OpenSSL Build Error on aarch64

### DIFF
--- a/chatbot/backend/Dockerfile
+++ b/chatbot/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-alpine@sha256:38e179a0f0436c97ecc76bcd378d7293ab3ee79e4b8c440fd
 
 # Update openssl
 RUN apk add --no-cache \
- openssl=3.3.3-r0
+ openssl=3.3.4-r0
 
 # Create a non-root user and group
 RUN addgroup -S appuser-group && adduser -D -H -G appuser-group appuser


### PR DESCRIPTION
Build on ARM (Mac M3) results in OpenSSL version conflict with the Alpine image.  Update docker file to openssl=3.3.4-r0 to match alpine image. 


Docker build error:

FROM python:3.12-alpine@sha256:38e179a0f0436c97ecc76bcd378d7293ab3ee79e4b8c440fdc7113670cb6e204

# Update openssl
RUN apk add --no-cache \
 openssl=3.3.3-r0

fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/aarch64/APKINDEX.tar.gz
ERROR: unable to select packages:
openssl-3.3.4-r0:
breaks: world[openssl=3.3.3-r0] 
